### PR TITLE
Fix a bug that's causing an error when executing the example provided in the readme

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -1,7 +1,7 @@
 import { prepare } from "https://deno.land/x/plugin_prepare/mod.ts";
 
 const releaseUrl =
-    "https://github.com/eliassjogreen/deno_webview/releases/download/0.1.2";
+    "https://github.com/eliassjogreen/deno_webview/releases/download/0.1.1";
 
 const plugin = await prepare({
     name: "deno_webview",


### PR DESCRIPTION
I was not able to run the example provided in readme probably because the release URL being pointed to the wrong version. 

I'm not sure but think this PR fixes the issue. 

This PR enables the default example to be executed(?)

Fixes #1 (probably) 