### PR TITLE
fix: use official extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
   "recommendations": [
-    "axetroy.vscode-deno"
+    "denoland.vscode-deno"
   ]
 }


### PR DESCRIPTION
From the recommend extension's docs: 

> The project is no longer maintained. move to official extension

https://github.com/axetroy/vscode-deno
https://marketplace.visualstudio.com/items?itemName=axetroy.vscode-deno

https://github.com/denoland/vscode_deno
https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno